### PR TITLE
Support to redirect including Japanese Markdown file

### DIFF
--- a/app/[which]/(which)/page.tsx
+++ b/app/[which]/(which)/page.tsx
@@ -20,6 +20,6 @@ export default async function Page({ params }: { params: Promise<{ which: string
         return null;
     }
     const firstMd = findFirstMd(tree);
-    if (firstMd) redirect(`/${which}/${firstMd}`);
+    if (firstMd) redirect(encodeURI(`/${which}/${firstMd}`));
     return null;
 }


### PR DESCRIPTION
If I created only `/content/mdblog/en/blog/About me - 私について.md` and then access `localhost:3000/blog`, error occurs.

### Reason
- It needs to encode URL.

### Check Content
- Create only `/content/mdblog/en/blog/About me - 私について.md`
- Access `localhost:3000/blog`
- If it doesn't error occurs, it is success.

